### PR TITLE
feature/category_entity | ADD: category 테이블 추가 및 restaurant 테이블과 연동.

### DIFF
--- a/src/entity/category.entity.ts
+++ b/src/entity/category.entity.ts
@@ -1,0 +1,21 @@
+import {
+  Entity,
+  Column,
+  PrimaryGeneratedColumn,
+} from 'typeorm';
+  
+@Entity()
+export default class Category {
+  @PrimaryGeneratedColumn()
+  id!: number;
+
+  @Column({
+    name: 'category_name',
+    type: 'varchar',
+    length: 100,
+    nullable: false,
+    default: '돈까스',
+    comment: '카테고리 이름',
+  })
+  categoryName!: string;
+}

--- a/src/entity/restaurant.entity.ts
+++ b/src/entity/restaurant.entity.ts
@@ -31,8 +31,8 @@ export default class Restaurant {
   location!: string;
 
   @ManyToMany(() => Category)
-  @JoinTable({ name: 'category_ids' })
-  categoryIds!: Category[];
+  @JoinTable({ name: 'category_list' })
+  categories!: Category[];
 
   @Column({
     name: 'img_dir',

--- a/src/entity/restaurant.entity.ts
+++ b/src/entity/restaurant.entity.ts
@@ -1,8 +1,11 @@
 import {
   Column,
   Entity,
+  JoinTable,
+  ManyToMany,
   PrimaryGeneratedColumn,
 } from 'typeorm';
+import Category from './category.entity'
 
 @Entity()
 export default class Restaurant {
@@ -27,14 +30,9 @@ export default class Restaurant {
   })
   location!: string;
 
-  @Column({
-    name: 'category',
-    type: 'varchar',
-    length: 100,
-    nullable: false,
-    comment: '식당 카테고리'
-  })
-  category!: string;
+  @ManyToMany(() => Category)
+  @JoinTable({ name: 'category_ids' })
+  categoryIds!: Category[];
 
   @Column({
     name: 'img_dir',

--- a/src/repository/category.repository.ts
+++ b/src/repository/category.repository.ts
@@ -1,0 +1,6 @@
+import AppDataSource from '../config/dataSource';
+import Category from '../entity/category.entity';
+
+const CategoryRepository = AppDataSource.getRepository(Category).extend({});
+
+export default CategoryRepository;


### PR DESCRIPTION
### 변경점
**1. Category Entity, Repo 추가**
- 식당에 여러 카테고리를 추가할 수 있게 하기 위해 Category Table을 위한 Entity를 추가했습니다.

- Entity에 맞춰 Data Source와 이어주는 repository도 추가했습니다.

**2. Restaurant Table과 연동**
- Restaurant가 여러 카테고리를 가질 수 있도록 restaurant.entity에 categoryIds를 추가하였습니다.

- 회의 때 얘기했던 내용과는 다르게 ManyToMany가 되었는데 식당이 여러 개의 카테고리를 가질 수 있고 카테고리도 여러 식당에 포함될 수 있어서 ManyToMany가 더 맞는 것 같습니다.

- ManyToMany가 추가되기 전에는 모두 ManyToOne밖에 없어서 몰랐는데 OneToMany를 사용하려면 해당 참조하려는 Entity에 ManyToOne을 꼭 만들어줘야 합니다.

- 이에 맞춰 categoryIds를 OneToMany로 설정할 경우 category Entity에도 ManyToOne을 설정해줘서 카테고리 테이블에 restaurant_id가 생기고 그에 맞춰 category_name이 동일한 row가 여러 개 생성되는 관계가 되어버립니다. (저희가 원하는 방식이 아닌 것 같습니다.)

- 제가 추가한 코드처럼 ManyToMany를 설정할 경우 JoinTable과 함께 사용하여 restaurant_id와 category_id를 column으로 갖는 테이블을 하나 추가해줍니다. 테이블 이름은 category_ids로 되어있는데 좀 더 나은 이름이 있을지 이야기 나눠보면 좋을 것 같습니다.

- 참고로 이전에 잘못 알고 있는 내용이 있었는데 OneToMany, ManyToOne, ManyToMany의 경우 두 번째 인자가 역방향 관계를 규정하는 거라고 합니다.

**이외에 개선점이나 오류가 있다면 알려주시면 감사하겠습니다!**