### PR TITLE
hotfix/entity | MOD: Entity Relation Hotfix

### DIFF
--- a/src/entity/candidate.entity.ts
+++ b/src/entity/candidate.entity.ts
@@ -12,11 +12,9 @@ export default class Candidate {
   @PrimaryGeneratedColumn()
   id!: number;
 
-  @ManyToOne(() => Poll, (poll) => poll.id)
-  @JoinColumn({ name: 'poll_id' })
-  pollId!: Poll;
+  @ManyToOne(() => Poll, (poll) => poll.candidates)
+  poll!: Poll;
 
-  @ManyToOne(() => Restaurant, (restaurant) => restaurant.id)
-  @JoinColumn({ name: 'restaurant_id' })
-  restaurantId!: Restaurant;
+  @ManyToOne(() => Restaurant)
+  restaurant!: Restaurant;
 }

--- a/src/entity/menu.entity.ts
+++ b/src/entity/menu.entity.ts
@@ -12,9 +12,8 @@ export default class Menu {
   @PrimaryGeneratedColumn()
   id!: number;
 
-  @ManyToOne(() => Restaurant, (restaurant) => restaurant.id)
-  @JoinColumn({ name: 'restaurant_id' })
-  restaurantId!: Restaurant;
+  @ManyToOne(() => Restaurant, (restaurant) => restaurant.menus)
+  restaurant!: Restaurant;
 
   @Column({
     name: 'menu_name',

--- a/src/entity/participant.entity.ts
+++ b/src/entity/participant.entity.ts
@@ -13,9 +13,8 @@ export default class Participant {
   @PrimaryGeneratedColumn()
   id!: number;
 
-  @ManyToOne(() => User, (user) => user.id, { nullable: true })
-  @JoinColumn({ name: 'user_id' })
-  userId?: User | null;
+  @ManyToOne(() => User, { nullable: true })
+  user?: User | null;
 
   @Column({
     name: 'display_name',
@@ -27,7 +26,6 @@ export default class Participant {
   })
   displayName!: string;
 
-  @ManyToOne(() => Poll, (poll) => poll.id)
-  @JoinColumn({ name: 'poll_id' })
-  pollId!: Poll;
+  @ManyToOne(() => Poll, (poll) => poll.participants)
+  poll!: Poll;
 }

--- a/src/entity/poll.entity.ts
+++ b/src/entity/poll.entity.ts
@@ -4,10 +4,13 @@ import {
   Entity,
   JoinColumn,
   ManyToOne,
+  OneToMany,
   PrimaryGeneratedColumn,
   UpdateDateColumn,
 } from 'typeorm';
 import User from './user.entity';
+import Participant from './participant.entity';
+import Candidate from './candidate.entity';
 
 @Entity()
 export default class Poll {
@@ -25,7 +28,6 @@ export default class Poll {
   pollName!: string;
 
   @ManyToOne(() => User, (user) => user.id)
-  @JoinColumn({ name: 'created_by' })
   createdBy!: User;
 
   @CreateDateColumn({ name: 'created_at', type: 'timestamp' })
@@ -33,6 +35,12 @@ export default class Poll {
 
   @UpdateDateColumn({ name: 'ended_at', type: 'timestamp', nullable: true })
   endedAt?: Date | null;
+
+  @OneToMany(() => Candidate, (candidate) => candidate.poll)
+  candidates!: Candidate[];
+
+  @OneToMany(() => Participant, (participant) => participant.poll)
+  participants!: Participant[];
 
   @Column({
     name: 'url',

--- a/src/entity/restaurant.entity.ts
+++ b/src/entity/restaurant.entity.ts
@@ -3,9 +3,11 @@ import {
   Entity,
   JoinTable,
   ManyToMany,
+  OneToMany,
   PrimaryGeneratedColumn,
 } from 'typeorm';
 import Category from './category.entity'
+import Menu from './menu.entity'
 
 @Entity()
 export default class Restaurant {
@@ -28,7 +30,10 @@ export default class Restaurant {
     nullable: false,
     comment: '식당 위치'
   })
-  location!: string;
+  location!: string; // Table?
+
+  @OneToMany(() => Menu, (menu) => menu.restaurant)
+  menus!: Menu[]
 
   @ManyToMany(() => Category)
   @JoinTable({ name: 'category_list' })

--- a/src/entity/vote.entity.ts
+++ b/src/entity/vote.entity.ts
@@ -12,11 +12,9 @@ export default class Vote {
   @PrimaryGeneratedColumn()
   id!: number;
 
-  @ManyToOne(() => Participant, (participant) => participant.id)
-  @JoinColumn({ name: 'voted_by' })
+  @ManyToOne(() => Participant)
   votedBy!: Participant;
 
-  @ManyToOne(() => Candidate, (candidate) => candidate.id)
-  @JoinColumn({ name: 'candidate_id' })
-  candidateId!: Candidate;
+  @ManyToOne(() => Candidate)
+  candidate!: Candidate;
 }


### PR DESCRIPTION
### 변경점
**1. JoinColumn 삭제**
- 이름을 설정하기 위해 사용했던 JoinColumn들이 삭제 되었습니다.

- 예를 들어, 변경 전 pollId의 경우 Poll 객체이기에 변수 이름이 poll로 변경되었고 이에 따라 Table 생성 시 자연스럽게 _id가 붙어도 이상이 없습니다.

**2. 변수 이름 수정**
- 객체인데도 불구하고 변수 이름 뒤에 Id가 붙은 변수들에서 Id를 제거했습니다.

- Repository 사용 시 이 변수들을 integer(id)가 아닌 객체로 보고 사용해주시면 됩니다.

- Table에는 '_id'가 붙고 integer이지만 TypeORM을 거쳐 Repository에서는 객체로 사용 가능한 것 같습니다.

**3. 역방향 관계 추가 및 수정**
- 편리한 Repository활용을 위하여 역방향이 필요할만한 부분들을 추가해주고 반대로 역방향이 필요 없는 부분들은 삭제했습니다.

- 예를 들어, Poll의 경우 candidates와 participants를 추가하여 이후 Repository 사용 시 Poll을 통해 candidates와 participants에 접근할 수 있도록 했습니다.

- 역방향의 경우 OneToMany로 설정되었는데 이 경우 mysql Table에 따로 Column이 추가되지는 않습니다. Repository에서 다룰 수 있는 변수 리스트만 추가해주는 것 같습니다.

**제가 잘못 알고 만든 부분들이 여러분께 혼동을 드린 점 사과드립니다.
혹시라도 이상한 점이나 개선점이 있다면 코멘트 달아주시면 감사하겠습니다!**