### PR TITLE
feature/guestlogin: 게스트 로그인 구현 

### DIFF
--- a/src/controller/participant/controller.ts
+++ b/src/controller/participant/controller.ts
@@ -1,0 +1,58 @@
+import { RequestHandler } from 'express';
+import { BadRequestError, UnauthorizedError } from '../../util/customErrors';
+import CreateParticipantInput from '../../type/participant/create.input';
+import ParticipantService from '../../service/participant.service';
+import PollService from '../../service/poll.service';
+
+//GET /guest/login?url=some-poll-url 처럼?
+// params 이용할 경우 /guest/login/:url
+export const showGuestLoginPage: RequestHandler = async (req, res, next) => {
+  try {
+    //GET 요청에서는 query나 params를 이용
+    const url = req.query.url; //url 쿼리 스트링이나 매개변수를 이용해야한다고 합니다(?)
+    if (!url) throw new BadRequestError('URL이 존재하지 않습니다.');
+    const poll = await PollService.getPollByUrl(url as string);
+    req.session.guest = { poll: poll }; //guest session에 poll 정보 넘기기
+    res.status(200).json(poll);
+  } catch (error) {
+    next(error);
+  }
+};
+
+//POST /guest/login
+export const loginGuest: RequestHandler = async (req, res, next) => {
+  try {
+    //request로 displayName 받아오기
+    const { displayName } = req.body;
+    //제대로 기입되지 않은 경우 BadRequest
+    if (!displayName) throw new BadRequestError('닉네임을 기입하세요.');
+    //세션에서 게스트 정보 조회(get에서 넘겨받은 세션)
+    const guestSession = req.session.guest; //guest session에서 정보 넘겨받기
+    if (!guestSession || !guestSession.poll)
+      throw new BadRequestError('게스트 정보가 없습니다');
+    //요 로직은 수정해도 괜찮을듯 합니다. 함수명이 너무 길어진.
+    const existingGuest =
+      await ParticipantService.getParticipantByDisplayNameandPollId(
+        guestSession.poll.id, //찾는 건 id로 검색
+        displayName,
+      );
+    if (existingGuest)
+      throw new BadRequestError('투표방에 동일 닉네임 사용자가 존재합니다.');
+
+    const createParticipantInput: CreateParticipantInput = {
+      displayName,
+      poll: guestSession.poll, //세션정보로 넘겨받은 poll정보
+    };
+    const guest = await ParticipantService.saveParticipant(
+      createParticipantInput,
+    );
+    req.session.guest = {
+      poll: guest.poll,
+      displayName: guest.displayName,
+    };
+    res.json(guest);
+    return res.redirect(`/poll/${guest.poll.id}`); //리다이렉트 값은 아직 존재하지 않아서
+  } catch (error) {
+    next(error);
+  }
+};

--- a/src/controller/participant/router.ts
+++ b/src/controller/participant/router.ts
@@ -1,0 +1,9 @@
+import { Router } from 'express';
+import { loginGuest, showGuestLoginPage } from './controller';
+
+const guestRouter = Router();
+
+guestRouter.get('/login', showGuestLoginPage);
+guestRouter.post('/login', loginGuest);
+
+export default guestRouter;

--- a/src/controller/poll/controller.ts
+++ b/src/controller/poll/controller.ts
@@ -18,7 +18,7 @@ export const getPollById: RequestHandler = async (req, res, next) => {
 
 export const getPollsByPollName: RequestHandler = async (req, res, next) => {
   try {
-    const pollName = String(req.query.pollName); 
+    const pollName = String(req.query.pollName);
 
     const polls = await PollService.getPollsByPollName(pollName);
 
@@ -30,8 +30,15 @@ export const getPollsByPollName: RequestHandler = async (req, res, next) => {
 
 export const createPoll: RequestHandler = async (req, res, next) => {
   try {
-    const { pollName, createdBy, url, createdAt, endedAt } = req.body as CreatePollInput;
-    const createPollInput: CreatePollInput = { pollName, createdBy, url, createdAt, endedAt };
+    const { pollName, createdUser, url, createdAt, endedAt } =
+      req.body as CreatePollInput;
+    const createPollInput: CreatePollInput = {
+      pollName,
+      createdUser,
+      url,
+      createdAt,
+      endedAt,
+    };
 
     const poll = await PollService.createPoll(createPollInput);
 

--- a/src/controller/router.ts
+++ b/src/controller/router.ts
@@ -1,10 +1,12 @@
 import { Router } from 'express';
 import userRouter from './user/router';
-import pollRouter from './poll/router'
+import pollRouter from './poll/router';
+import guestRouter from './participant/router';
 
 const router = Router();
 
 router.use('/user', userRouter);
 router.use('/poll', pollRouter);
+router.use('/guest', guestRouter);
 
 export default router;

--- a/src/controller/user/controller.ts
+++ b/src/controller/user/controller.ts
@@ -16,7 +16,7 @@ export const loginUser: RequestHandler = async (req, res, next) => {
     if (!username || !password)
       throw new BadRequestError('아이디와 비밀번호를 모두 입력해주세요');
     // username에 해당하는 user 정보 가져오기
-    const user = await UserService.getUsersByUsername(username);
+    const user = await UserService.getUserByUsername(username);
     // 없다면 UnauthorizedError (?)
     if (!user) throw new UnauthorizedError('해당하는 유저가 없습니다.');
     // 해싱 이용 비밀번호 확인
@@ -43,13 +43,15 @@ export const createUser: RequestHandler = async (req, res, next) => {
     //아이디 16자 이하, 비밀번호 일치, 닉네임 길이 32자 이하
     if (!username || username.length > 16)
       throw new BadRequestError('아이디가 적절하지 않습니다.');
-    if (!password) throw new BadRequestError('비밀번호가 비어 있습니다.');
+    if (!password || password.length < 8)
+      //비밀번호 8자 이상 입력
+      throw new BadRequestError('비밀번호가 적절하지 않습니다.');
     if (password !== confirmPassword)
       throw new BadRequestError('비밀번호가 서로 일치 하지 않습니다.');
     if (!displayName || displayName.length > 32)
       throw new BadRequestError('닉네임이 적절하지 않습니다.');
     // 중복 검사 (?)
-    const existingUser = await UserService.getUsersByUsername(username);
+    const existingUser = await UserService.getUserByUsername(username);
     if (existingUser) throw new BadRequestError('이미 존재하는 아이디입니다.');
     //비밀번호 해싱
     const hashedPassword = await generatePassword(password);

--- a/src/service/participant.service.ts
+++ b/src/service/participant.service.ts
@@ -1,0 +1,34 @@
+import { create } from 'domain';
+import Participant from '../entity/participant.entity';
+import Poll from '../entity/poll.entity';
+import ParticipantRepository from '../repository/participant.repository';
+import CreateParticipantInput from '../type/participant/create.input';
+import { InternalServerError } from '../util/customErrors';
+
+export default class ParticipantService {
+  static async getParticipantByDisplayNameandPollId(
+    poll_id: number, //변수명...
+    displayName: string,
+  ): Promise<Participant | null> {
+    try {
+      return await ParticipantRepository.findOne({
+        where: { poll: { id: poll_id }, displayName },
+      });
+    } catch (error) {
+      throw new InternalServerError('참가자 정보를 찾을 수 없습니다.');
+    }
+  }
+  static async saveParticipant(
+    //participant 저장
+    createParticipantInput: CreateParticipantInput,
+  ): Promise<Participant> {
+    try {
+      const participantEntity = await ParticipantRepository.create(
+        createParticipantInput,
+      );
+      return await ParticipantRepository.save(participantEntity);
+    } catch (error) {
+      throw new InternalServerError('게스트 정보를 저장하는데 실패했습니다.');
+    }
+  }
+}

--- a/src/service/poll.service.ts
+++ b/src/service/poll.service.ts
@@ -28,4 +28,13 @@ export default class PollService {
       throw new InternalServerError('투표 정보를 저장하는데 실패했습니다.');
     }
   }
+
+  //url로 poll 구분 -> 뭔가 에러 안나게끔 했는데 findOne 쓰고 싶음
+  static async getPollByUrl(url: string): Promise<Poll> {
+    try {
+      return await PollRepository.findOneOrFail({ where: { url } });
+    } catch (error) {
+      throw new InternalServerError('투표 정보를 불러오는데 실패했습니다.');
+    }
+  }
 }

--- a/src/service/user.service.ts
+++ b/src/service/user.service.ts
@@ -12,7 +12,8 @@ export default class UserService {
     }
   }
 
-  static async getUsersByUsername(username: string): Promise<User | null> {
+  static async getUserByUsername(username: string): Promise<User | null> {
+    //단수형으로 수정
     try {
       return await UserRepository.findOne({ where: { username } }); //User 단일 반환
     } catch (error) {

--- a/src/type/participant/create.input.ts
+++ b/src/type/participant/create.input.ts
@@ -1,0 +1,9 @@
+import User from '../../entity/user.entity';
+import Poll from '../../entity/poll.entity';
+
+//헤민 연승 코드 참고
+export default interface CreateParticipantInput {
+  user?: User | null; //게스트의 경우는 Id가 없기 때문에 null 추가
+  displayName: string;
+  poll: Poll; //poll로 이름 수정
+}

--- a/src/type/poll/create.input.ts
+++ b/src/type/poll/create.input.ts
@@ -2,7 +2,7 @@ import User from '../../entity/user.entity';
 
 export default interface CreatePollInput {
   pollName: string;
-  createdBy: User;
+  createdUser: User; //Entity 명 바뀌면서 수정
   url?: string;
   createdAt: Date;
   endedAt?: Date;


### PR DESCRIPTION
### 변경점

1. GET /guest/login
GET /guest/login 의 경우에는 url을 쿼리로 받은 후, 해당 url을 가진 poll 정보를 찾아 게스트 세션에 넘겨주었습니다.

2. POST /guest/login
POST /guest/login 의 경우 먼저 displayName을 입력 받고, guest session이 있는 경우에 게스트 로그인이 가능하도록 구현했습니다. 동일 poll_id 내의 같은 닉네임이 존재하는 경우에는 badrequestError를 띄우는 것으로 구현했습니다.
해당 displayName과 poll 정보를 이용해 participant 테이블에 저장후, poll_id에 맞춰 리디렉션을 반환하도록 구현했습니다.

3. 변수명 함수명 수정
entity의 맞춰 일부 변경되지 않은 변수명, 함수명을 수정했습니다.

4. 비밀번호 조건 추가
user login내의 비밀번호 8자 이상을 추가했습니다.

### 테스트 가이드

- 임의로 poll table 내의 row를 한 줄 추가
- insomnia 를 통해 get /guest/login 를 실행합니다. 이때 쿼리로 url string을 넣습니다.
- 그후 post /guest/login은 displayName을 json 형태로 전송합니다.

**해당 부분 테스트 완료 되었으며, 코드 내 로직 개선점이 있다면 편하게 말씀해주세요:)**


