### PR TITLE
FTR: poll history를 얻는 기능 추가

### DIFF
--- a/src/controller/poll/router.ts
+++ b/src/controller/poll/router.ts
@@ -5,6 +5,7 @@ import {
   creatPollAndCandidate,
   getPollResultById,
   getPollForm,
+  getPollsByUserId,
 } from './controller';
 
 const pollRouter = Router();
@@ -12,7 +13,8 @@ const pollRouter = Router();
 pollRouter.get('/', getSettingform);
 pollRouter.get('/restaurant', createFilteredRestaurants);
 pollRouter.post('/restaurant', creatPollAndCandidate);
-pollRouter.get('/result/:pollId', getPollResultById);
-pollRouter.get('/:pollId', getPollForm);
+pollRouter.get('/result/:pollId(\\d+)', getPollResultById);
+pollRouter.get('/:pollId(\\d+)', getPollForm);
+pollRouter.get('/history', getPollsByUserId);
 
 export default pollRouter;

--- a/src/service/poll.service.ts
+++ b/src/service/poll.service.ts
@@ -36,4 +36,14 @@ export default class PollService {
       throw new InternalServerError('투표 정보를 불러오는데 실패했습니다.');
     }
   }
+
+  static async getPollsByUserId(userId: number): Promise<Poll[]> {
+    try {
+      return await PollRepository.find({
+        where: { createdUser: { id: userId } },
+      });
+    } catch (error) {
+      throw new InternalServerError('투표 정보를 불러오는데 실패했습니다.');
+    }
+  }
 }


### PR DESCRIPTION
변경점
- `service/poll.service.ts`에 `getPollsByUserId()` 함수를 추가했습니다. 유저의 아이디를 인자로 받아, 해당 유저가 만든 poll 객체들의 배열을 반환합니다. 
- `controller/poll/controller.ts`에 `getPollsByUserId()` 함수를 추가했습니다. 우선 `req.session.user`를 확인하여 현재 사용자가 로그인된 상태인지 확인합니다. 로그인된 상태라면, 유저의 아이디를 이용해 해당 사용자가 만든 poll 객체들을 `res.json()`으로 넣어줍니다. 또한 prettier에 의한 자잘한 코드 수정이 있었습니다.
- `controller/poll/router.ts`에서 `GET /poll/history` 요청을 상술한 `getPollsByUserId()`로 연결해주었습니다. 또한 `/:pollId`를 `req.params`로 사용하는 부분에서, `pollId`를 정수형으로 제한하였습니다. 이걸 하지 않으면 `/poll/history`라는 요청을 보냈을 때 `history`를 `pollId`로 인식하게 됩니다. 